### PR TITLE
add gradient colors for echips and emult

### DIFF
--- a/lovely/gradients.toml
+++ b/lovely/gradients.toml
@@ -1,0 +1,17 @@
+[manifest]
+version = "1.0.0"
+priority = 0
+
+# update gradients
+[[patches]]
+[patches.pattern]
+target = "game.lua"
+pattern = "self.C.DARK_EDITION[2] = math.min(self.C.DARK_EDITION[3], self.C.DARK_EDITION[1])"
+position = "after"
+payload = '''
+for k, grad in pairs(Talisman.gradients.list) do
+    grad:update(dt)
+    G.C[k] = grad.current_colour
+end
+'''
+match_indent = true

--- a/smods.lua
+++ b/smods.lua
@@ -101,6 +101,7 @@ curmod.debug_info = Talisman.debug
 
 require("talisman.smods.ind_effect")
 require("talisman.smods.scoring_calc")
+require("talisman.smods.gradients")
 
 --[[SMODS.Joker{
   key = "test",

--- a/talisman.lua
+++ b/talisman.lua
@@ -13,6 +13,7 @@ require("talisman.localization")
 require("talisman.card")
 require("talisman.configtab")
 require("talisman.noanims")
+require("talisman.gradients")
 require("talisman.sanitizer")
 require("talisman.debug")
 if not Talisman.config_file.disable_omega then

--- a/talisman/configinit.lua
+++ b/talisman/configinit.lua
@@ -18,6 +18,7 @@ Talisman.config_file = {
     debug_coroutine = false,
     big_ante = false,
     notation = "Balatro",
+    exponential_colours = 1,
 
     enable_compat = false,
     thread_sanitize = 'modify',

--- a/talisman/effects.lua
+++ b/talisman/effects.lua
@@ -105,7 +105,8 @@ Talisman.effects.chips = {
 	key = 'chip',
 	keyPlural = 'chips',
 	effectTableKey = 'hand_chips',
-	soundFormat = 'talisman_%schip'
+	soundFormat = 'talisman_%schip',
+	colorKey = 'talisman_echips',
 }
 
 --- @class t.EffectInit
@@ -113,9 +114,18 @@ Talisman.effects.mult = {
 	key = 'mult',
 	keyPlural = 'mult',
 	effectTableKey = 'mult',
-	soundFormat = 'talisman_%smult'
+	soundFormat = 'talisman_%smult',
+	colorKey = 'talisman_emult',
 }
 
-Talisman.effects.registerIndex(Talisman.effects.chips, 0) -- xchips
+-- xchips
+-- this can just be removed now honestly
+Talisman.effects.registerIndex({
+	key = 'chip',
+	keyPlural = 'chips',
+	effectTableKey = 'hand_chips',
+	soundFormat = 'talisman_%schip',
+	colorKey = 'CHIPS'
+}, 0)
 Talisman.effects.register(Talisman.effects.chips)
 Talisman.effects.register(Talisman.effects.mult)

--- a/talisman/gradients.lua
+++ b/talisman/gradients.lua
@@ -1,0 +1,83 @@
+--- @class t.Gradient
+--- @field key string
+--- @field current_colour [number, number, number, number]
+--- @field colours [number, number, number, number][]
+--- @field cycle number
+--- @field update fun(self: t.Gradient, dt: number)
+
+--- @class t.GradientInit
+--- @field key string
+--- @field colours [number, number, number, number][]
+--- @field cycle number
+--- @field update fun(self: t.Gradient, dt: number)
+
+Talisman.gradients = {}
+--- @type table<string, t.Gradient>
+Talisman.gradients.list = {}
+local gradlist = Talisman.gradients.list
+
+function Talisman.gradients.register(init)
+    assert(init.key)
+    gradlist[init.key] = {
+        key = init.key,
+        colours = init.colours,
+        current_colour = HEX("000000"), -- placeholder value
+        cycle = init.cycle,
+        update = init.update,
+    }
+    G.C[init.key] = gradlist[init.key].current_colour
+    return gradlist[init.key]
+end
+
+local slib = SMODS and SMODS.Mods and (SMODS.Mods.Spectrallib or {}).can_load
+local function update_exp_colour(self, _)
+    if slib then
+        for i = 1, 4 do
+            self.current_colour[i] = SMODS.Gradients["slib_" .. self.key]
+        end
+        return
+    end
+
+    local opt = Talisman.config_file.exponential_colours
+    if opt == 1 then
+        local interp = math.cos(G.TIMERS.REAL * 2 * math.pi / self.cycle) * 0.5 + 0.5
+        for i = 1, 4 do
+            self.current_colour[i] = self.colours[1][i] * (1-interp) + self.colours[2][i] * interp
+        end
+    elseif opt == 2 then
+        for i = 1, 4 do
+            self.current_colour[i] = G.C.DARK_EDITION[i]
+        end
+    end
+end
+
+Talisman.gradients.register {
+    key = "echips",
+    colours = {
+        HEX("41bed9"),
+        HEX("5674e9"),
+    },
+    cycle = 4,
+    update = update_exp_colour,
+}
+
+Talisman.gradients.register {
+    key = "emult",
+    colours = {
+        HEX("ff73ad"),
+        HEX("db005f")
+    },
+    cycle = 4,
+    update = update_exp_colour,
+}
+
+local lc = loc_colour
+function loc_colour(_c, _default, ...)
+	if not G.ARGS.LOC_COLOURS then
+		lc()
+	end
+	for k, _ in pairs(Talisman.gradients.list) do
+        G.ARGS.LOC_COLOURS[k:lower()] = G.C[k]
+    end
+	return lc(_c, _default, ...)
+end

--- a/talisman/localization/en-us.lua
+++ b/talisman/localization/en-us.lua
@@ -18,6 +18,10 @@ return {
     talisman_notations_letter = 'Letter',
     talisman_notations_array = 'Array',
 
+    tal_exp_colours = 'Exponential Chips and Mult colours',
+    tal_exp_colour_default = 'Default',
+    tal_exp_colour_classic = 'Classic (G.C.DARK_EDITION)',
+
     tal_debug_coroutine = 'Debug Coroutine',
     tal_debug_coroutine_warning = {
         'Captures stack trace of the scoring coroutine when',

--- a/talisman/smods/gradients.lua
+++ b/talisman/smods/gradients.lua
@@ -1,0 +1,33 @@
+local gradlist = Talisman.gradients.list
+
+SMODS.Gradient {
+    key = "echips",
+    colours = {
+        HEX("41bed9"),
+        HEX("5674e9"),
+    },
+    cycle = 4,
+    update = function(self, dt)
+        gradlist.echips:update(dt)
+
+        for i = 1, 4 do
+            self[i] = gradlist.echips.current_colour[i]
+        end
+    end,
+}
+
+SMODS.Gradient {
+    key = "emult",
+    colours = {
+        HEX("ff73ad"),
+        HEX("db005f")
+    },
+    cycle = 4,
+    update = function(self, dt)
+        gradlist.emult:update(dt)
+
+        for i = 1, 4 do
+            self[i] = gradlist.emult.current_colour[i]
+        end
+    end,
+}


### PR DESCRIPTION
adds the gradient colors used by Spectrallib for its echips and emult. this will also use spectrallib's settings and config if possible